### PR TITLE
Fixes, Cycle Detection & Early Spice Schema DSL Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `IAuthorization` protocol in [src/eacl/core.clj](src/eacl/core.clj) defines 
 - `(eacl/can? client subject permission resource) => true | false`
 - `(eacl/lookup-subjects client filters) => {:data [subjects...], cursor 'next-cursor}`
 - `(eacl/lookup-resources client filters) => {:data [resources...], :cursor 'next-cursor}`.
-- `(eacl/count-resources client filters) => <count>` materializes full index, so can be slow. Use sparingly.
+- `(eacl/count-resources client filters) => {:keys [count limit cursor]}` supports limit & cursor for iterated counting. Use sparingly with `:limit -1` for all results.
 - `(eacl/read-relationships client filters) => [relationships...]`
 - `(eacl/write-relationships! client updates) => {:zed/token 'db-basis}`,
   - where `updates` is just a coll of `[operation relationship]` where `operation` is one of `:create`, `:touch` or `:delete`.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Embedded AuthZ offers some advantages for typical use-cases:
 In a ReBAC system like EACL, _Subjects_ & _Resources_ are related via _Relationships_.
 
 A `Relationship` is just a 3-tuple of `[subject relation resource]`, e.g.
-- `[user1 :owner account1]` means subject `user1` is the `:owner` of resource `account1`,
-- whereas `[account1 :account product1]` means subject `account1` is the `:account` for resource `product1`.
+- `[user1 :owner account1]` means subject `user1` is the `:owner` of resource `account1`, and
+- `[account1 :account product1]` means subject `account1` is the `:account` for resource `product1`.
 
-To create a relationship, defined a potential `Relation`, like so:
+To create a relationship, define a potential `Relation`, like so:
 
 ```clojure
 ; Account Resource:

--- a/src/eacl/datomic/impl/base.clj
+++ b/src/eacl/datomic/impl/base.clj
@@ -31,8 +31,8 @@
 
 (defn ->permission-id
   "Uses (str kw) instead of (name kw) to retain namespaces. Leading colons are expected."
-  [resource-type permission-name arrow target-type relation]
-  (str "eacl:permission:" resource-type ":" permission-name ":" arrow ":" target-type ":" relation))
+  [resource-type permission-name arrow target-type relation-or-permission]
+  (str "eacl:permission:" resource-type ":" permission-name ":" arrow ":" target-type ":" relation-or-permission))
 
 (defn Permission
   "Defines a Permission via
@@ -89,11 +89,13 @@
   {:pre [(keyword? resource-type)
          (keyword? permission-name)
          (map? spec)
+         (or relation permission)
          (not (and relation permission))]}                  ; a permission resolves via a relation or a permission, but not both.
+  ; confusion here between permission & permission-name.
   (cond
     ;; Direct permission: {:relation relation-name}
     relation
-    ; id format: 'eacl:permission:{resource-type}:{permission-name}:{arrow}:{relation|permission}:{target-name}'
+    ; id format: 'eacl:permission:{resource-type}:{permission-name}:{arrow}:{:relation|:permission}:{target-name}'
     {:eacl/id                              (->permission-id resource-type permission-name arrow :relation relation)
      :eacl.permission/resource-type        resource-type
      :eacl.permission/permission-name      permission-name
@@ -103,7 +105,7 @@
 
     ;; Arrow permission: {:arrow source-relation :permission target-permission}
     permission
-    {:eacl/id                              (->permission-id resource-type permission-name arrow :permission relation)
+    {:eacl/id                              (->permission-id resource-type permission-name arrow :permission permission)
      :eacl.permission/resource-type        resource-type
      :eacl.permission/permission-name      permission-name
      :eacl.permission/source-relation-name arrow            ; this can be :self.

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -407,7 +407,7 @@
                            (map extract-resource-id-from-rel-tuple-datom)
                            (filter some?)
                            (filter (fn [resource-eid]
-                                     (and resource-eid (if cursor-eid (> % cursor-eid) true)))))))
+                                     (and resource-eid (if cursor-eid (> resource-eid cursor-eid) true)))))))
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq resource-seqs)

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -87,50 +87,59 @@
   Returns vector of path maps, where each path is:
   {:type :relation, :name keyword, :subject-type keyword} for direct
   or {:type :arrow, :via keyword, :target-type keyword, :sub-paths [paths]} for arrows."
-  [db resource-type permission-name]
-  (let [perm-defs (find-permission-defs db resource-type permission-name)]
-    (->> perm-defs
-      (keep (fn [{:as                   perm-def
-                  :eacl.permission/keys [source-relation-name
-                                         target-type
-                                         target-name]}]
-              ; how to handle {:relation :self :permission :local-permission} ?
-              (log/debug 'perm-def perm-def)
-              (assert resource-type "resource-type missing")
-              (assert source-relation-name "source-relation-name missing")
-              (if (= :self source-relation-name)
-                (case target-type
-                  :relation (resolve-self-relation db resource-type target-name) ; target-name can be nil here. why?
-                  :permission {:type              :self-permission
-                               :target-permission target-name
-                               :resource-type     resource-type})
-                (if-let [via-rel-def (find-relation-def db resource-type source-relation-name)]
-                  (let [intermediate-type (:eacl.relation/subject-type via-rel-def)]
-                    {:type              :arrow
-                     :via               source-relation-name ; this can be :self, but we don't handle it
-                     :target-type       intermediate-type   ;; This is the actual type of the intermediate
-                     :target-permission (when (= target-type :permission) target-name)
-                     :target-relation   (when (= target-type :relation) target-name)
-                     :sub-paths         (case target-type
-                                          ;; Recursive permission call - types already resolved in recursion
-                                          :permission (get-permission-paths db intermediate-type target-name)
-                                          ;; Direct relation - build the path with proper type resolution
-                                          :relation (if-let [target-rel-def (find-relation-def db intermediate-type target-name)]
-                                                      [{:type         :relation
-                                                        :name         target-name
-                                                        :subject-type (:eacl.relation/subject-type target-rel-def)}]
-                                                      (do   ; Return empty sub-paths if missing Relation
-                                                        (log/warn "Missing Relation definition for arrow target relation"
-                                                          {:intermediate-type    intermediate-type
-                                                           :target-relation-name target-name})
-                                                        [])))}) ; Skip this permission path
-                  (do
-                    (log/warn "Missing Relation definition for via relation"
-                      {:resource-type     resource-type
-                       :via-relation-name source-relation-name})
-                    nil)))))
+  ([db resource-type permission-name]
+   (get-permission-paths db resource-type permission-name #{}))
+  ([db resource-type permission-name visited-perms]
+   ;; Cycle detection: check if we've already visited this permission
+   (let [perm-key [resource-type permission-name]]
+     (if (contains? visited-perms perm-key)
+       (do
+         (log/warn "Cycle detected: " perm-key " in " visited-perms)
+         [])                                                ; Return empty paths if we detect a cycle. This should be detected during schema writes.
+       (let [updated-visited (conj visited-perms perm-key)
+             perm-defs       (find-permission-defs db resource-type permission-name)]
+         (->> perm-defs
+           (keep (fn [{:as                   perm-def
+                       :eacl.permission/keys [source-relation-name
+                                              target-type
+                                              target-name]}]
+                   ; how to handle {:relation :self :permission :local-permission} ?
+                   ;(log/debug 'perm-def perm-def)
+                   (assert resource-type "resource-type missing")
+                   (assert source-relation-name "source-relation-name missing")
+                   (if (= :self source-relation-name)
+                     (case target-type
+                       :relation (resolve-self-relation db resource-type target-name) ; target-name can be nil here. why?
+                       :permission {:type              :self-permission
+                                    :target-permission target-name
+                                    :resource-type     resource-type})
+                     (if-let [via-rel-def (find-relation-def db resource-type source-relation-name)]
+                       (let [intermediate-type (:eacl.relation/subject-type via-rel-def)]
+                         {:type              :arrow
+                          :via               source-relation-name ; this can be :self, but we don't handle it
+                          :target-type       intermediate-type ;; This is the actual type of the intermediate
+                          :target-permission (when (= target-type :permission) target-name)
+                          :target-relation   (when (= target-type :relation) target-name)
+                          :sub-paths         (case target-type
+                                               ;; Recursive permission call with cycle detection
+                                               :permission (get-permission-paths db intermediate-type target-name updated-visited)
+                                               ;; Direct relation - build the path with proper type resolution
+                                               :relation (if-let [target-rel-def (find-relation-def db intermediate-type target-name)]
+                                                           [{:type         :relation
+                                                             :name         target-name
+                                                             :subject-type (:eacl.relation/subject-type target-rel-def)}]
+                                                           (do ; Return empty sub-paths if missing Relation
+                                                             (log/warn "Missing Relation definition for arrow target relation"
+                                                               {:intermediate-type    intermediate-type
+                                                                :target-relation-name target-name})
+                                                             [])))}) ; Skip this permission path
+                       (do
+                         (log/warn "Missing Relation definition for via relation"
+                           {:resource-type     resource-type
+                            :via-relation-name source-relation-name})
+                         nil)))))
 
-      (vec))))
+           (vec)))))))
 
 (defn traverse-single-path
   "Recursively traverses a single path from a subject to find matching resources.
@@ -268,89 +277,94 @@
   For direct relations: Uses forward index from subject
   For arrow permissions: Uses reverse traversal - finds intermediates
   with permission first, then resources connected to them."
-  [db subject-type subject-eid permission-name resource-type cursor-eid limit]
-  (let [paths           (get-permission-paths db resource-type permission-name)
-        ;; For each path, determine traversal strategy
-        path-results    (->> paths
-                          (map (fn [{:as path, path-type :type}]
-                                 (case path-type
+  ([db subject-type subject-eid permission-name resource-type cursor-eid]
+   (traverse-permission-path db subject-type subject-eid permission-name resource-type cursor-eid #{}))
+  ([db subject-type subject-eid permission-name resource-type cursor-eid visited-paths]
+   ;; Cycle detection for traversal
+   (let [path-key [subject-type subject-eid permission-name resource-type]]
+     (if (contains? visited-paths path-key)
+       []                                                   ; Return empty if we detect a traversal cycle
+       (let [updated-visited   (conj visited-paths path-key)
+             paths             (get-permission-paths db resource-type permission-name)
+             ;; For each path, determine traversal strategy
+             lazy-path-results (->> paths
+                                 (map (fn [{:as path, path-type :type}]
+                                        (case path-type
 
-                                   :relation
-                                   ;; Direct relation - forward traversal
-                                   (when (= subject-type (:subject-type path))
-                                     (let [tuple-attr  :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                           start-tuple [subject-type subject-eid (:name path) resource-type (or cursor-eid 0)]
-                                           end-tuple   [subject-type subject-eid (:name path) resource-type Long/MAX_VALUE]]
-                                       (->> (d/index-range db tuple-attr start-tuple end-tuple)
-                                         (map (fn [datom]
-                                                (let [resource-eid (extract-resource-id-from-rel-tuple-datom datom)]
-                                                  (when (> resource-eid (or cursor-eid 0))
-                                                    [resource-eid path]))))
-                                         (filter some?))))
+                                          :relation
+                                          ;; Direct relation - forward traversal
+                                          (when (= subject-type (:subject-type path))
+                                            (let [tuple-attr  :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                  start-tuple [subject-type subject-eid (:name path) resource-type 0] ;(or cursor-eid 0)]
+                                                  end-tuple   [subject-type subject-eid (:name path) resource-type Long/MAX_VALUE]]
+                                              (->> (d/index-range db tuple-attr start-tuple end-tuple)
+                                                (map (fn [datom]
+                                                       (let [resource-eid (extract-resource-id-from-rel-tuple-datom datom)]
+                                                         (when (> resource-eid (or cursor-eid 0))
+                                                           [resource-eid path]))))
+                                                (filter some?))))
 
-                                   :self-permission
-                                   ;; Self-permission: recursively find resources where subject has target permission
-                                   (let [target-permission (:target-permission path)]
-                                     ;; Recursively traverse with target permission to find matching resources
-                                     (traverse-permission-path db subject-type subject-eid
-                                       target-permission resource-type cursor-eid limit))
+                                          :self-permission
+                                          ;; Self-permission: recursively find resources where subject has target permission
+                                          (let [target-permission (:target-permission path)]
+                                            ;; Recursively traverse with target permission to find matching resources
+                                            (traverse-permission-path db subject-type subject-eid
+                                              target-permission resource-type cursor-eid updated-visited))
 
-                                   :arrow
-                                   ;; Arrow permission - traverse using index-range
-                                   (let [via-relation      (:via path)
-                                         intermediate-type (:target-type path)]
-                                     (if (:target-relation path)
-                                       ;; Arrow to relation: find intermediates with that relation to subject
-                                       (let [target-relation         (:target-relation path)
-                                             intermediate-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                             intermediate-start      [subject-type subject-eid target-relation intermediate-type cursor-eid] ; cursor-eid can be nil
-                                             intermediate-end        [subject-type subject-eid target-relation intermediate-type Long/MAX_VALUE]
-                                             intermediate-eids       (->> (d/index-range db intermediate-tuple-attr
-                                                                            intermediate-start intermediate-end)
-                                                                       (map extract-resource-id-from-rel-tuple-datom))]
-                                         ;; Now find resources connected to these intermediates using index-range
-                                         (let [resource-seqs
-                                               (map (fn [intermediate-eid]
-                                                      ;; Use forward index from intermediate to resources
-                                                      (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                            resource-start      [intermediate-type intermediate-eid via-relation resource-type cursor-eid] ; cursor-eid can be nil
-                                                            resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
-                                                        (->> (d/index-range db resource-tuple-attr resource-start resource-end)
-                                                          (map extract-resource-id-from-rel-tuple-datom)
-                                                          (filter #(> % (or cursor-eid 0)))
-                                                          (map (fn [resource-eid] [resource-eid path])))))
-                                                 intermediate-eids)]
-                                           ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
-                                           (if (seq resource-seqs)
-                                             (lazy-merge-dedupe-sort-by first resource-seqs)
-                                             [])))
-                                       ;; Arrow to permission: recursively find intermediates with permission
-                                       (let [target-permission    (:target-permission path)
-                                             ;; First get all intermediates the subject has permission on
-                                             intermediate-results (traverse-permission-path db subject-type subject-eid
-                                                                    target-permission
-                                                                    intermediate-type nil Integer/MAX_VALUE) ; this nil is expensive. how to avoid?
-                                             intermediate-eids    (map first intermediate-results)]
-                                         ;; Then find resources connected to these intermediates using index-range
-                                         (let [resource-seqs (->> intermediate-eids
-                                                               (map (fn [intermediate-eid]
-                                                                      ;; Use forward index from intermediate to resources
-                                                                      (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                                                                            resource-start      [intermediate-type intermediate-eid via-relation resource-type cursor-eid]
-                                                                            resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
-                                                                        (->> (d/index-range db resource-tuple-attr resource-start resource-end)
-                                                                          (map extract-resource-id-from-rel-tuple-datom)
-                                                                          (filter #(> % (or cursor-eid 0)))
-                                                                          (map (fn [resource-eid] [resource-eid path])))))))]
-                                           ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
-                                           (if (seq resource-seqs)
-                                             (lazy-merge-dedupe-sort-by first resource-seqs)
-                                             []))))))))
-                          (filter some?)
-                          (lazy-merge-dedupe-sort-by first)) ; Merge results from all paths
-        ;; Take the requested limit from merged results
-        limited-results (take limit path-results)]
-    limited-results))
+                                          :arrow
+                                          ;; Arrow permission - traverse using index-range
+                                          (let [via-relation      (:via path)
+                                                intermediate-type (:target-type path)]
+                                            (if (:target-relation path)
+                                              ;; Arrow to relation: find intermediates with that relation to subject
+                                              (let [target-relation         (:target-relation path)
+                                                    intermediate-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                    intermediate-start      [subject-type subject-eid target-relation intermediate-type 0] ;cursor-eid] ; cursor-eid can be nil
+                                                    intermediate-end        [subject-type subject-eid target-relation intermediate-type Long/MAX_VALUE]
+                                                    intermediate-eids       (->> (d/index-range db intermediate-tuple-attr
+                                                                                   intermediate-start intermediate-end)
+                                                                              (map extract-resource-id-from-rel-tuple-datom))]
+                                                ;; Now find resources connected to these intermediates using index-range
+                                                (let [resource-seqs
+                                                      (map (fn [intermediate-eid]
+                                                             ;; Use forward index from intermediate to resources
+                                                             (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                                   resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid] ; cursor-eid can be nil
+                                                                   resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
+                                                               (->> (d/index-range db resource-tuple-attr resource-start resource-end)
+                                                                 (map extract-resource-id-from-rel-tuple-datom)
+                                                                 (filter #(> % (or cursor-eid 0)))
+                                                                 (map (fn [resource-eid] [resource-eid path])))))
+                                                        intermediate-eids)]
+                                                  ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
+                                                  (if (seq resource-seqs)
+                                                    (lazy-merge-dedupe-sort-by first resource-seqs)
+                                                    [])))
+                                              ;; Arrow to permission: recursively find intermediates with permission
+                                              (let [target-permission    (:target-permission path)
+                                                    ;; First get all intermediates the subject has permission on
+                                                    intermediate-results (traverse-permission-path db subject-type subject-eid
+                                                                           target-permission
+                                                                           intermediate-type nil updated-visited) ; this nil is expensive. how to avoid?
+                                                    intermediate-eids    (map first intermediate-results)]
+                                                ;; Then find resources connected to these intermediates using index-range
+                                                (let [resource-seqs (->> intermediate-eids
+                                                                      (map (fn [intermediate-eid]
+                                                                             ;; Use forward index from intermediate to resources
+                                                                             (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
+                                                                                   resource-start      [intermediate-type intermediate-eid via-relation resource-type 0] ;cursor-eid]
+                                                                                   resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
+                                                                               (->> (d/index-range db resource-tuple-attr resource-start resource-end)
+                                                                                 (map extract-resource-id-from-rel-tuple-datom)
+                                                                                 (filter #(> % (or cursor-eid 0)))
+                                                                                 (map (fn [resource-eid] [resource-eid path])))))))]
+                                                  ;; Use lazy-merge-dedupe-sort-by to combine sorted sequences from all intermediates
+                                                  (if (seq resource-seqs)
+                                                    (lazy-merge-dedupe-sort-by first resource-seqs)
+                                                    []))))))))
+                                 (filter some?)
+                                 (lazy-merge-dedupe-sort-by first))] ; Merge results from all paths
+         lazy-path-results)))))
 
 (defn direct-match-datoms-in-relationship-index
   [db subject-type subject-eid relation-name resource-type resource-eid]
@@ -361,12 +375,13 @@
 (defn traverse-permission-path-via-subject
   "Subject must be known. Returns lazy seq of resource eids."
   [db subject-type subject-eid path resource-type cursor-eid]
+  (prn 'traverse-permission-path-via-subject 'cursor-eid cursor-eid)
   (case (:type path)
     :relation
     ;; Direct relation - forward traversal
     (when (= subject-type (:subject-type path))
       (let [tuple-attr  :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-            start-tuple [subject-type subject-eid (:name path) resource-type cursor-eid] ; cursor-eid can be nil.
+            start-tuple [subject-type subject-eid (:name path) resource-type (or cursor-eid 0)]
             end-tuple   [subject-type subject-eid (:name path) resource-type Long/MAX_VALUE]]
         (->> (d/index-range db tuple-attr start-tuple end-tuple)
           (map extract-resource-id-from-rel-tuple-datom)
@@ -377,7 +392,7 @@
     ;; Self-permission: recursively get resources where subject has target permission
     (let [target-permission (:target-permission path)]
       ;; Use traverse-permission-path to get resources where subject has target permission
-      (->> (traverse-permission-path db subject-type subject-eid target-permission resource-type cursor-eid Long/MAX_VALUE)
+      (->> (traverse-permission-path db subject-type subject-eid target-permission resource-type cursor-eid #{})
         (map first)                                         ; Extract resource-eids from [resource-eid path] tuples
         (filter (fn [resource-eid]
                   (and resource-eid (> resource-eid (or cursor-eid 0)))))))
@@ -391,7 +406,7 @@
         (let [target-relation         (:target-relation path)
               ;; Step 1: Find intermediates that subject has target-relation to
               intermediate-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-              intermediate-start      [subject-type subject-eid target-relation intermediate-type cursor-eid]
+              intermediate-start      [subject-type subject-eid target-relation intermediate-type 0]
               intermediate-end        [subject-type subject-eid target-relation intermediate-type Long/MAX_VALUE]
               intermediate-eids       (->> (d/index-range db intermediate-tuple-attr intermediate-start intermediate-end)
                                         (map extract-resource-id-from-rel-tuple-datom)
@@ -401,13 +416,13 @@
                 (map (fn [intermediate-eid]
                        ;; Use forward index from intermediate to resources via via-relation
                        (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                             resource-start      [intermediate-type intermediate-eid via-relation resource-type cursor-eid]
+                             resource-start      [intermediate-type intermediate-eid via-relation resource-type (or cursor-eid 0)]
                              resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
                          (->> (d/index-range db resource-tuple-attr resource-start resource-end)
                            (map extract-resource-id-from-rel-tuple-datom)
                            (filter some?)
                            (filter (fn [resource-eid]
-                                     (and resource-eid (if cursor-eid (> resource-eid cursor-eid) true)))))))
+                                     (and resource-eid (> resource-eid (or cursor-eid 0))))))))
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq resource-seqs)
@@ -419,19 +434,19 @@
               intermediate-results (traverse-permission-path db subject-type subject-eid
                                      target-permission
                                      intermediate-type
-                                     ; this nil looks expensive.
-                                     nil Long/MAX_VALUE)    ; note limit is infinity.
+                                     cursor-eid
+                                     #{})
               intermediate-eids    (map first intermediate-results)]
           ;; Now find resources connected to these intermediates using index-range
           (let [resource-seqs
                 (map (fn [intermediate-eid]
                        ;; Use forward index from intermediate to resources
                        (let [resource-tuple-attr :eacl.relationship/subject-type+subject+relation-name+resource-type+resource
-                             resource-start      [intermediate-type intermediate-eid via-relation resource-type cursor-eid] ; cursor-eid can be nil.
+                             resource-start      [intermediate-type intermediate-eid via-relation resource-type (or cursor-eid 0)]
                              resource-end        [intermediate-type intermediate-eid via-relation resource-type Long/MAX_VALUE]]
                          (->> (d/index-range db resource-tuple-attr resource-start resource-end)
                            (map extract-resource-id-from-rel-tuple-datom)
-                           (filter some?)                   ; not sure how this can happen given we're mapping over a seq.
+                           (filter some?)
                            (filter (fn [resource-eid] (> resource-eid (or cursor-eid 0)))))))
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
@@ -446,30 +461,35 @@
   (let [{subject-type :type
          subject-id   :id} subject
 
-        subject-eid    (d/entid db subject-id)
+        subject-eid         (d/entid db subject-id)
 
         {cursor-resource :resource} cursor
-        cursor-eid     (:id cursor-resource)                ; can be nil.
+        cursor-eid          (:id cursor-resource)           ; can be nil.
+        ; we can't validate cursor because may have been deleted since previous call.
+        _                   (prn 'lazy-merged-lookup-resources 'cursor cursor)
 
-        paths          (get-permission-paths db type permission)
-        path-seqs      (->> paths
-                         (keep (fn [path]
-                                 (let [results (traverse-permission-path-via-subject db subject-type subject-eid
-                                                 path type cursor-eid)]
-                                   (when (seq results)
-                                     results)))))           ; Already sorted by eid
+        paths               (get-permission-paths db type permission)
+        path-seqs           (->> paths
+                              (keep (fn [path]
+                                      (let [results (traverse-permission-path-via-subject db subject-type subject-eid
+                                                      path type cursor-eid)]
+                                        (when (seq results)
+                                          results)))))      ; Already sorted by eid
 
-        merged-results (if (seq path-seqs)
-                         (lazy-merge-dedupe-sort path-seqs)
-                         [])]
-    merged-results))
+        lazy-merged-results (if (seq path-seqs)
+                              (lazy-merge-dedupe-sort path-seqs)
+                              [])]
+    lazy-merged-results))
 
 (defn lookup-resources
+  "Default :limit 1000, pass negative value e.g. -1 for all results."
   [db {:as   query
        :keys [subject permission resource/type limit cursor]
        :or   {limit 1000}}]
   (let [merged-results  (lazy-merged-lookup-resources db query)
-        limited-results (take limit merged-results)
+        limited-results (if (pos? limit)
+                          (take limit merged-results)
+                          merged-results)
         resources       (map #(spice-object type %) limited-results)
         last-resource   (last resources)
         next-cursor     {:resource (or last-resource (:resource cursor))}]
@@ -597,7 +617,9 @@
        :or   {limit 1000}}]
   {:pre [(:type resource) (:id resource)]}
   (let [merged-results  (lazy-merged-lookup-subjects db query)
-        limited-results (take limit merged-results)
+        limited-results (if (pos? limit)
+                          (take limit merged-results)
+                          merged-results)
         subjects        (map #(spice-object type %) limited-results)
         last-subject    (last subjects)
         next-cursor     {:subject (or last-subject (:subject cursor))}]

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -85,8 +85,8 @@
 (defn get-permission-paths
   "Recursively builds paths granting permission-name on resource-type.
   Returns vector of path maps, where each path is:
-  {:type :relation, :name keyword, :subject-type keyword} for direct
-  or {:type :arrow, :via keyword, :target-type keyword, :sub-paths [paths]} for arrows."
+  {:type :relation, :name keyword, :subject-type keyword} for direct path, or
+  {:type :arrow, :via keyword, :target-type keyword, :sub-paths [paths]} for arrows."
   ([db resource-type permission-name]
    (get-permission-paths db resource-type permission-name #{}))
   ([db resource-type permission-name visited-perms]
@@ -375,7 +375,7 @@
 (defn traverse-permission-path-via-subject
   "Subject must be known. Returns lazy seq of resource eids."
   [db subject-type subject-eid path resource-type cursor-eid]
-  (prn 'traverse-permission-path-via-subject 'cursor-eid cursor-eid)
+  ;(prn 'traverse-permission-path-via-subject 'cursor-eid cursor-eid)
   (case (:type path)
     :relation
     ;; Direct relation - forward traversal
@@ -434,7 +434,7 @@
               intermediate-results (traverse-permission-path db subject-type subject-eid
                                      target-permission
                                      intermediate-type
-                                     cursor-eid
+                                     nil
                                      #{})
               intermediate-eids    (map first intermediate-results)]
           ;; Now find resources connected to these intermediates using index-range

--- a/src/eacl/datomic/impl/indexed.clj
+++ b/src/eacl/datomic/impl/indexed.clj
@@ -407,7 +407,7 @@
                            (map extract-resource-id-from-rel-tuple-datom)
                            (filter some?)
                            (filter (fn [resource-eid]
-                                     (and resource-eid #(if cursor-eid (> % cursor-eid) true)))))))
+                                     (and resource-eid (if cursor-eid (> % cursor-eid) true)))))))
                   intermediate-eids)]
             ;; Use lazy-merge-dedupe-sort to combine sorted sequences from all intermediates
             (if (seq resource-seqs)

--- a/src/eacl/datomic/spice_parser.clj
+++ b/src/eacl/datomic/spice_parser.clj
@@ -1,0 +1,246 @@
+(ns eacl.datomic.spice-parser
+  "WIP."
+  (:require [instaparse.core :as insta]
+            [clojure.pprint]
+            [clojure.string]
+            [eacl.datomic.core]
+            [eacl.datomic.impl :as impl]))
+
+;      primary-expr = identifier | <'('> permission-expr <')'>
+;; Define the SpiceDB grammar with auto-whitespace
+(def spicedb-parser
+  (insta/parser
+    "schema = definition+
+
+     definition = <'definition'> identifier <'{'> definition-body <'}'>
+     definition-body = (relation | permission)*
+
+     relation-name = identifier
+     relation-subject-type = identifier
+     relation = <'relation'> relation-name <':'> relation-subject-type
+
+     <permission-name> = identifier
+     permission = <'permission'> permission-name <'='> permission-expr
+
+     permission-operator = '+' | '-'
+
+     permission-expr = direct-or-arrow (permission-operator direct-or-arrow)*
+
+     <permission-relation> = identifier
+
+     direct-permission = permission-relation
+
+     <arrow-via-permission> = identifier
+     <arrow-relation> = identifier
+     arrow-permission = arrow-relation <'->'> arrow-via-permission
+
+     <direct-or-arrow> = direct-permission | arrow-permission
+
+     <identifier> = #'[a-zA-Z_][a-zA-Z0-9_]*'"
+    :auto-whitespace :standard))
+
+;; Example SpiceDB schema
+(def example-schema
+  "definition user {}
+
+   definition platform {
+     relation super_admin: user
+   }
+
+   definition account {
+     relation platform: platform
+     relation owner: user
+
+     permission admin = owner + platform->super_admin
+     permission view = owner + admin
+     permission update = admin
+   }")
+
+;; Parse the schema
+(defn parse-schema [schema-str]
+  (spicedb-parser schema-str))
+
+;; Pretty print parse tree
+(defn pretty-print-tree [tree]
+  (clojure.pprint/pprint tree))
+
+;; Extract relations from definition body
+(defn extract-relations [definition-body]
+  (if (and (vector? definition-body) (= :definition-body (first definition-body)))
+    (->> (rest definition-body)
+         (filter #(and (vector? %) (= :relation (first %))))
+         (map (fn [[_ rel-name type-name]]
+                [(second rel-name) (keyword (second type-name))]))
+         (into {}))
+    []))
+
+;; Extract permissions from definition body
+(defn extract-permissions [definition-body]
+  (if (and (vector? definition-body) (= :definition-body (first definition-body)))
+    (->> (rest definition-body)
+         (filter #(and (vector? %) (= :permission (first %))))
+         (map (fn [[_ perm-name expr]]
+                {:name       perm-name ; this was (second perm-name), why?
+                 :expression expr})))
+    []))
+
+;; Extract definitions from parse tree
+(defn extract-definitions [parse-tree]
+  (->> parse-tree
+       (filter #(and (vector? %) (= :definition (first %))))
+       (map (fn [[_ name definition-body]]
+              ; why was this (second name)?
+              [name {:relations   (extract-relations definition-body)
+                     :permissions (extract-permissions definition-body)}]))
+       (into {})))
+
+;; Transform parse tree to more usable data structure
+(defn transform-schema
+  "This just calls extract-definitions."
+  [parse-tree]
+  (when (and (vector? parse-tree) (= :schema (first parse-tree)))
+    {:definitions (extract-definitions (rest parse-tree))}))
+
+;; Helper to parse expressions
+(defn parse-permission-expression [expr-str]
+  (let [full-schema (str "definition temp { permission test = " expr-str " }")
+        parsed (spicedb-parser full-schema)]
+    (if (insta/failure? parsed)
+      (do
+        (println "Failed to parse expression:" expr-str)
+        (println "Error:" (insta/get-failure parsed))
+        nil)
+      ;; Path: schema -> definition -> definition-body -> permission -> permission-expr
+      (get-in parsed [1 2 1 2]))))
+
+;; Transform expressions to a more usable format
+(defn transform-expression [expr]
+  (cond
+    (vector? expr)
+    (case (first expr)
+      :union-expr (let [operands (rest expr)]
+                    (if (= 1 (count operands))
+                      (transform-expression (first operands))
+                      {:type :union
+                       :operands (map transform-expression operands)}))
+      :arrow-expr (let [parts (rest expr)]
+                    (if (= 1 (count parts))
+                      (transform-expression (first parts))
+                      {:type :arrow
+                       :base (transform-expression (first parts))
+                       :path (map #(second %) (rest parts))}))
+      :primary-expr (transform-expression (second expr))
+      :identifier {:type :identifier :name (second expr)}
+      :permission-expr (transform-expression (second expr))
+      expr)
+    :else expr))
+
+;; Pretty print expressions in a readable format
+(defn format-expression [expr]
+  (cond
+    (map? expr)
+    (case (:type expr)
+      :union (str "(" (clojure.string/join " + " (map format-expression (:operands expr))) ")")
+      :arrow (str (format-expression (:base expr)) "->" (clojure.string/join "->" (:path expr)))
+      :identifier (:name expr)
+      (str expr))
+    :else (str expr)))
+
+;; Analyze a specific definition
+(defn analyze-definition [schema-str def-name]
+  (let [parsed (parse-schema schema-str)]
+    (when-not (insta/failure? parsed)
+      (let [definitions (extract-definitions (rest parsed))
+            target-def (first (filter #(= def-name (:name %)) definitions))]
+        (when target-def
+          (println (str "Definition: " def-name))
+          (println "Relations:")
+          (doseq [rel (:relations target-def)]
+            (println (str "  " (:name rel) " : " (:type rel))))
+          (println "Permissions:")
+          (doseq [perm (:permissions target-def)]
+            (println (str "  " (:name perm) " = "
+                          (format-expression (transform-expression (:expression perm))))))
+          target-def)))))
+
+;; Usage examples
+(defn demo []
+  (println "=== Parsing SpiceDB Schema ===")
+
+  ;; Parse the full schema
+  (let [parsed (parse-schema example-schema)]
+    (if (insta/failure? parsed)
+      (do
+        (println "Parse failed:")
+        (println (insta/get-failure parsed)))
+      (do
+        (println "\n1. Schema structure:")
+        (let [transformed (transform-schema parsed)]
+          (doseq [def (:definitions transformed)]
+            (println (str "- " (:name def)
+                          " (" (count (:relations def)) " relations, "
+                          (count (:permissions def)) " permissions)"))))
+
+        (println "\n2. Detailed breakdown:")
+        (doseq [def-name ["user" "platform" "account"]]
+          (analyze-definition example-schema def-name)
+          (println)))))
+
+
+  (rest (get (parse-permission-expression "owner + platform->super_admin") 1))
+
+  ;; Parse individual expressions
+  (println "\n=== Parsing Individual Expressions ===")
+  (doseq [expr ["owner + admin"
+                "platform->super_admin"
+                "owner + platform->super_admin"
+                "account->admin + vpc->admin + shared_admin"]]
+    (let [parsed-expr (parse-permission-expression expr)]
+      (if parsed-expr
+        (do
+          (println (str "Expression: " expr))
+          (println (str "Parsed as: " (format-expression (transform-expression parsed-expr))))
+          (println (str "Structure: " (transform-expression parsed-expr)))
+          (println))
+        (println (str "Failed to parse: " expr)))))
+
+  ;; Demonstrate error handling
+  (println "\n=== Error Handling ===")
+  (let [bad-schema "definition user { invalid syntax }"]
+    (let [result (parse-schema bad-schema)]
+      (if (insta/failure? result)
+        (println "Parse error (expected):" (insta/get-failure result))
+        (println "Unexpected success")))))
+
+(defn ->eacl-schema [parse-tree]) ; wip
+
+(defn extract-expr [permission-exp]
+  (-> permission-exp
+      (get 1)
+      (rest)))
+
+;; Run the demo
+(comment
+  (def *defs
+    (let [parse-tree (parse-schema example-schema)]
+      (:definitions (transform-schema parse-tree))))
+
+  (doall
+    (for [[resource-type spec :as definition] *defs]
+      (do
+        (prn 'definition definition)
+        (let [{:keys [relations permissions]} spec]
+          (concat
+            (for [{:as           relation
+                   relation-name :name
+                   subject-type  :type} relations]
+              (do
+                (prn 'relation relation)
+                (impl/Relation (keyword resource-type) (keyword relation-name) (keyword subject-type))))
+            (for [{:as             permission
+                   permission-name :name
+                   expr            :expression} permissions]
+              (extract-expr expr)))))))
+
+  (demo)
+  (analyze-definition example-schema "account"))

--- a/test/eacl/datomic/fixtures.clj
+++ b/test/eacl/datomic/fixtures.clj
@@ -111,6 +111,12 @@
    (Permission :server :view {:arrow :nic :permission :view})
    ;(Permission :server :view {:relation :shared_admin})
 
+   (Permission :server :view {:relation :shared_member})
+   (Permission :server :view {:relation :backup_creator})
+
+   (Permission :server :start {:arrow :account :permission :admin})
+   (Permission :server :start {:relation :shared_admin})
+
    ; definition server { permission edit = owner } ; admin?
    (Permission :server :edit {:permission :admin})
 

--- a/test/eacl/datomic/fixtures.clj
+++ b/test/eacl/datomic/fixtures.clj
@@ -97,6 +97,7 @@
    ;; Servers:
    (Relation :server :account :account)
    (Relation :server :shared_admin :user)
+   (Relation :server :shared_member :user)
    (Relation :server :vpc :vpc)
 
    ; definition server { permission admin = account->admin + vpc->admin + shared_admin }
@@ -219,15 +220,6 @@
     :db/ident :user/super-user
     :eacl/id  "super-user"}
 
-   ; Accounts
-   {:db/id    "account-1"
-    :db/ident :test/account1
-    :eacl/id  "account-1"}
-
-   {:db/id    "account-2"
-    :db/ident :test/account2
-    :eacl/id  "account-2"}
-
    ;; Servers
    ;; ...Account 1 Servers:
    {:db/id    "account1-server1"
@@ -241,6 +233,18 @@
    {:db/id    "account2-server1"
     :db/ident :test/server2
     :eacl/id  "account2-server1"}
+
+   ; Order matters here: accounts are intentionally after servers
+   ; to force eids to be larger than servers above.
+   ; Accounts
+   {:db/id    "account-1"
+    :db/ident :test/account1
+    :eacl/id  "account-1"}
+
+   {:db/id    "account-2"
+    :db/ident :test/account2
+    :eacl/id  "account-2"}
+
 
    ; VPC
    {:db/id    "vpc-1"
@@ -341,6 +345,19 @@
     relations+permissions
     entity-fixtures
     relationship-fixtures))
+
+(def txes-additional-account3+server
+  "To test accounts & servers with higher eids."
+  [{:db/id    "account3-server3.1"
+    :db/ident :test/account3-server1
+    :eacl/id  "account3-server3.1"}
+
+   {:db/id    "account-3"
+    :db/ident :test/account3
+    :eacl/id  "account-3"}
+
+   (Relationship (->account "account-3") :account (->server "account3-server3.1"))
+   (Relationship (->user :test/user1) :owner (->account "account-3"))])
 
 ;; (For Later) Team Membership:
 ;(Relationship "user-2" :team/member "team-2")

--- a/test/eacl/datomic/impl/indexed_test.clj
+++ b/test/eacl/datomic/impl/indexed_test.clj
@@ -79,7 +79,7 @@
 
 (deftest permission-helper-tests
   (testing "Permission helper with new unified API"
-    (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::admin::self:relation::owner"
+    (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::admin::self::relation::owner"
                              :resource-type        :server
                              :permission-name      :admin
                              :source-relation-name :self
@@ -87,7 +87,7 @@
                              :target-name          :owner}
           (Permission :server :admin {:relation :owner})))
     (testing "arrow permission to permission"
-      (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::admin::account:permission::admin"
+      (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::admin::account::permission::admin"
                                :resource-type        :server
                                :permission-name      :admin
                                :source-relation-name :account
@@ -95,7 +95,7 @@
                                :target-name          :admin}
             (Permission :server :admin {:arrow :account :permission :admin}))))
     (testing "arrow permission to relation"
-      (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::view::account:relation::owner"
+      (is (= #:eacl.permission{:eacl/id              "eacl:permission::server::view::account::relation::owner"
                                :resource-type        :server
                                :permission-name      :view
                                :source-relation-name :account
@@ -440,7 +440,7 @@
 
     (testing "what happens when find-relation-def is called with source-relation-name `:self`?"
       ; what do we expect here?
-      (is (impl.indexed/find-relation-def db :server :self)))
+      (is (nil? (impl.indexed/find-relation-def db :server :self))))
 
     (testing "lookup of :view against :vpc works"
       (is (= #{(->vpc "vpc-1")
@@ -659,16 +659,16 @@
                                                :cursor        page2-cursor})))))
 
           (testing "now test pagination for :view permission on :account for  account->super_admin with {:arrow :account :relation :super_admin}"
-            (let [both-pages          (lookup-resources db' {:limit         5
+            (let [both-pages          (lookup-resources db' {:limit         3
                                                              :cursor        nil ; :cursor nil = first page.
                                                              :resource/type :account
                                                              :permission    :view
                                                              :subject       (->user super-user-eid)})
 
                   both-pages-resolved (paginated-data->spice db' (:data both-pages))
-                  [page1-expected
-                   page2-expected
-                   page3-expected] (partition-all 1 both-pages-resolved)
+                  _ (prn 'both-pages-resolved both-pages-resolved)
+                  [page1-expected page2-expected] (partition-all 1 both-pages-resolved)
+                  page3-expected []                         ; empty.
 
                   {:as          page1
                    page1-data   :data
@@ -680,7 +680,7 @@
                   ;_                   (prn 'page1 'cursor (:cursor page1))
                   {:as          page2
                    page2-data   :data
-                   page2-cursor :cursor} (lookup-resources db' {:limit         5
+                   page2-cursor :cursor} (lookup-resources db' {:limit         1
                                                                 :cursor        (:cursor page1)
                                                                 :resource/type :account
                                                                 :permission    :view
@@ -708,39 +708,24 @@
                 ; we probably need a flag for empty, but empty :data implies that.
                 (is (= page2-cursor page3-cursor)))
 
-              (testing "limit 5 should include all 4 results, in sorted order" ; (depends on tuple index or costly sort)
+              (prn 'both-pages both-pages)
+
+              (testing "both-pages :limit 3 should include both results, in sorted order" ; (depends on tuple index or costly sort)
                 (is (= [(spice-object :account "account-1")
                         (spice-object :account "account-2")]
                       (paginated-data->spice db' (:data both-pages)))))
 
-              (testing "page1 with 0-1 of 4 should match the first 2 results"
+              (testing "page1 contains first result only (no. 1 of 2"
                 (is (= page1-expected (paginated-data->spice db' page1-data))))
 
-              (testing "page2 with 2-4 of 4 should match the second two results"
+              (testing "page2 contains second result only (no. 2 of 2)"
                 (is (= page2-expected (paginated-data->spice db' page2-data))))
 
-              (testing "page3 with 5-6 of 4 should be empty (results exhausted)"
-                (is (nil? page3-expected))
+              (testing "page3 should be empty (results exhausted)"
+                (is (empty? page3-expected))
                 (is (empty? (paginated-data->spice db' page3-data))))
 
-              (testing "repeating page2 query with limit: 1 should return only the first result on that page"
-                (is (= (take 1 page2-expected)
-                      (->> (lookup-resources db' {:limit         1
-                                                  :cursor        page1-cursor
-                                                  :resource/type :account
-                                                  :permission    :view
-                                                  :subject       (->user super-user-eid)})
-                        (paginated->spice db')))))
-
-              (testing "repeat page2 query with limit: 10 should return remainder"
-                (is (= (drop 2 both-pages-resolved)
-                      (->> (lookup-resources db' {:limit         10
-                                                  :cursor        page1-cursor
-                                                  :resource/type :account
-                                                  :permission    :view
-                                                  :subject       (->user super-user-eid)})
-                        (paginated->spice db')))))
-
+                (prn 'failing-test-here)
               (testing "lookup-resources returns cursor input when looking beyond any values"
                 (let [page3-empty (lookup-resources db' {:limit         100
                                                          :cursor        page2-cursor
@@ -750,12 +735,14 @@
                   (is (empty? (:data page3-empty)))
                   (is (= page2-cursor (:cursor page3-empty)))))
 
+              ;; server.view tests follow
               (testing "count-resources should return count of all result"
                 (is (= 4 (count-resources db' {:resource/type :server
                                                :permission    :view
                                                :subject       (->user super-user-eid)}))))
 
-              (testing "count-resources is also cursor-sensitive"
+              (testing "count-resources should be cursor-sensitive. why isn't it?"
+                (is (:resource page1-cursor))
                 (is (= 2 (count-resources db' {:resource/type :server
                                                :permission    :view
                                                :cursor        page1-cursor
@@ -838,14 +825,14 @@
   (let [db (d/db *conn*)]
     (testing "Direct path traversal"
       (let [user1-eid (d/entid db :test/user1)
-            resources (impl.indexed/traverse-permission-path db :user user1-eid :view :account nil 10)]
+            resources (impl.indexed/traverse-permission-path db :user user1-eid :view :account nil)]
         ;; User1 should be able to view account1
         (is (seq resources))
         (is (some #(= (d/entid db :test/account1) (first %)) resources))))
 
     (testing "Arrow path traversal"
       (let [user1-eid (d/entid db :test/user1)
-            resources (impl.indexed/traverse-permission-path db :user user1-eid :view :server nil 10)]
+            resources (impl.indexed/traverse-permission-path db :user user1-eid :view :server nil)]
         ;; User1 should be able to view servers in account1
         (is (seq resources))
         (is (= [(->server "account1-server1")
@@ -854,7 +841,7 @@
 
     (testing "Complex nested path traversal"
       (let [vpc1-eid  (d/entid db :test/vpc1)
-            resources (impl.indexed/traverse-permission-path db :vpc vpc1-eid :view :server nil 10)]
+            resources (impl.indexed/traverse-permission-path db :vpc vpc1-eid :view :server nil)]
         ;; VPC1 should be able to view servers through the network chain
         (is (= [(d/entid db :test/server1)]
               (map first resources)))))                     ; hard to understand destructuring here.
@@ -862,12 +849,13 @@
     (testing "Cursor pagination"
       (let [user1-eid    (d/entid db :test/user1)
             ;; Get first result
-            first-batch  (impl.indexed/traverse-permission-path db :user user1-eid :view :server nil 1)
+            first-batch  (impl.indexed/traverse-permission-path db :user user1-eid :view :server nil)
             first-eid    (ffirst first-batch)
             ;; Get next result after cursor
-            second-batch (impl.indexed/traverse-permission-path db :user user1-eid :view :server first-eid 1)]
-        (is (= 1 (count first-batch)))
-        (is (= 1 (count second-batch)))
+            second-batch (impl.indexed/traverse-permission-path db :user user1-eid :view :server first-eid)]
+        (is (= ["account1-server1"
+                "account1-server2"] (map (comp :eacl/id #(d/entity db %) first) first-batch)))
+        (is (= ["account1-server2"] (map (comp :eacl/id #(d/entity db %) first) second-batch)))
         (is (not= (ffirst first-batch) (ffirst second-batch)))))))
 
 (deftest lookup-resources-optimized-tests
@@ -970,8 +958,10 @@
     (testing "Arrow permission check"
       ;; User1 can view server1 through account admin
       (is (impl.indexed/can? db (->user :test/user1) :view (->server :test/server1)))
+      (is (impl.indexed/can? db (->user :test/user1) :start (->server :test/server1)))
       ;; User2 cannot view server1
-      (is (not (impl.indexed/can? db (->user :test/user2) :view (->server :test/server1)))))
+      (is (not (impl.indexed/can? db (->user :test/user2) :view (->server :test/server1))))
+      (is (not (impl.indexed/can? db (->user :test/user2) :start (->server :test/server1)))))
 
     (testing "Super user permissions"
       (is (impl.indexed/can? db (->user :user/super-user) :view (->server :test/server1)))
@@ -1012,12 +1002,8 @@
 
       ; this causes infinite loop because we do not guard against loops yet.
       ; this should be prevented at schema write time, not runtime.
-      (is (lookup-resources db'
-            {:subject       (->user :test/user1)
-             :permission    :view
-             :resource/type :server}))
-      (is (thrown? java.lang.Exception
-            (lookup-resources db'
+      (testing "cycles should not throw (we return empty), as they should be prevented at schema write time"
+        (is (lookup-resources db'
               {:subject       (->user :test/user1)
                :permission    :view
                :resource/type :server}))))))

--- a/test/eacl/datomic/parser_test.clj
+++ b/test/eacl/datomic/parser_test.clj
@@ -1,0 +1,108 @@
+(ns eacl.datomic.parser_test
+    (:require [clojure.test :as t :refer [deftest testing is]]
+              [eacl.datomic.spice-parser :as parser]))
+
+(def example-schema-string
+  "definition user {}
+
+   definition platform {
+     relation super_admin: user
+   }
+
+   definition account {
+     relation platform: platform
+     relation owner: user
+
+     permission admin = owner + platform->super_admin
+     permission view = owner + admin
+     permission update = admin
+   }")
+
+(def parsed-example-schema
+  [:schema
+   [:definition "user" [:definition-body]]
+   [:definition "platform"
+    [:definition-body
+     [:relation [:relation-name "super_admin"] [:relation-subject-type "user"]]]]
+   [:definition "account"
+    [:definition-body
+     [:relation [:relation-name "platform"]
+      [:relation-subject-type "platform"]]
+     [:relation [:relation-name "owner"]
+      [:relation-subject-type "user"]]
+     [:permission "admin"
+      [:permission-expr
+       [:direct-permission "owner"]
+       [:permission-operator "+"]
+       [:arrow-permission "platform" "super_admin"]]]
+     [:permission "view"
+      [:permission-expr
+       [:direct-permission "owner"]
+       [:permission-operator "+"]
+       [:direct-permission "admin"]]]
+     [:permission "update"
+      [:permission-expr
+       [:direct-permission "admin"]]]]]])
+
+(deftest spicedb-schema-parsing-tests
+
+  (testing "we can parse an empty resource definition"
+    (is (= [:schema
+            [:definition "user"
+             [:definition-body]]] (parser/parse-schema "definition user {}"))))
+
+  (is (= [:permission-expr
+          [:direct-permission "owner"]
+          [:permission-operator "+"]
+          [:direct-permission "admin"]] (parser/parse-permission-expression "owner + admin")))
+
+  (testing "we can parse arrow permissions with one level of nesting"
+    (is (= [:permission-expr
+            [:direct-permission "owner"]
+            [:permission-operator "+"]
+            [:arrow-permission "account" "admin"]]
+           (parser/parse-permission-expression "owner + account->admin"))))
+
+  ;(testing "parsing permission definitions"
+  ;  (doseq [expr ["owner + admin"
+  ;                "platform->super_admin"
+  ;                "owner + platform->super_admin"
+  ;                "account->admin + vpc->admin + shared_admin"]]
+  ;    (let [parsed-expr (parser/parse-permission-expression "owner + admin")]
+  ;      (if parsed-expr
+  ;        (do
+  ;          (println (str "Expression: " expr))
+  ;          (println (str "Parsed as: " (format-expression (transform-expression parsed-expr))))
+  ;          (println (str "Structure: " (transform-expression parsed-expr)))
+  ;          (println))
+  ;        (println (str "Failed to parse: " expr))))))
+
+  #_(def example-schema
+      "definition user {}
+
+     definition platform {
+       relation super_admin: user
+     }
+
+     definition account {
+       relation platform: platform
+       relation owner: user
+
+       permission admin = owner + platform->super_admin
+       permission view = owner + admin
+       permission update = admin
+     }")
+
+  (testing "we can parse Spice schema DSL using Instaparse"
+    (let [parse-tree (parser/parse-schema example-schema-string)]
+      (is (= parsed-example-schema parse-tree))
+
+      (testing "we can extract resource definitions w/relations + permissions"
+        (let [definitions (parser/extract-definitions parse-tree)]
+          (is (= {} definitions)))
+
+        (testing "we can coerce definitions (relations + permissions) to EACL schema maps"
+          ; how to handle sort order? do we need to track order, or call sort?
+          (is (= {} (parser/transform-schema parse-tree)))))))
+
+  (testing "ensure we warn against unsupported Spice schema like exclusion permissions"))

--- a/test/eacl/datomic/schema_test.clj
+++ b/test/eacl/datomic/schema_test.clj
@@ -1,9 +1,52 @@
 (ns eacl.datomic.schema-test
+  "WIP."
   (:require [clojure.test :as t :refer (deftest testing is)]
             [datomic.api :as d]
             [eacl.datomic.datomic-helpers :refer [with-mem-conn]]
             [eacl.datomic.schema :as schema]
+<<<<<<< Updated upstream
             [eacl.datomic.fixtures :as fixtures]))
+=======
+            [eacl.schema-fixtures :as schema-fixtures]))
+;
+;; OK, so what we want to happen here,
+;; is take schema as a map,
+;; or ideally in Spice syntax.
+;; what would be optimal?
+;; the quick fix is :db/ident. We can do that, but you'll have to return to it.
+;
+;; Why not just try and parse it and resolve references?
+;
+
+(deftest eacl-schema-stable-ident-tests
+  (with-mem-conn [conn schema/v6-schema]
+    (testing "we can transact Realtions & Permissions twice without datom conflicts after introduction of :eacl/id for Relation & Permission."
+      (is @(d/transact conn fixtures/relations+permissions))
+      (is @(d/transact conn fixtures/relations+permissions))
+      (is (schema/read-schema (d/db conn))))))
+
+(deftest eacl-schema-comparison-tests
+  (testing "we can calculate additions & retractions"
+    ; note we do not care about shape of set elements here.
+    (is (= {:additions   #{:added}
+            :unchanged   #{:retained}
+            :retractions #{:deleted}}
+          (schema/calc-set-deltas
+            #{:deleted :retained}
+            #{:retained :added})))
+
+    (is (= {:relations   {:additions   #{:added}
+                          :unchanged   #{:retained}
+                          :retractions #{:deleted}}
+            :permissions {:additions   #{:added}
+                          :unchanged   #{:retained}
+                          :retractions #{:deleted :also-deleted}}}
+          (schema/compare-schema
+            {:relations   [:deleted :retained]
+             :permissions [:deleted :retained :also-deleted]}
+            {:relations   [:retained :added]
+             :permissions [:retained :added]})))))
+>>>>>>> Stashed changes
 
 (deftest eacl-datomic-schema-tests
   (with-mem-conn [conn schema/v6-schema]


### PR DESCRIPTION
Breaking Changes:
- Schema IDs have changed. Normalised Relation & Permission ID, so :eacl/id will change in CA branch. Can do an update for staging, otherwise it will re-create. I'll manage this.
- `eacl/count-resources` now returns `{:keys [count limit cursor]}` to support iterative counting in batches. Respects limit & cursor. Pass `:limit -1` for all results (defaults to -1. most other calls default to `:limit 1000`).